### PR TITLE
Partially revert "renaming, add communication file"

### DIFF
--- a/src/GrayScott.jl
+++ b/src/GrayScott.jl
@@ -33,7 +33,7 @@ end
 
 function main(args::Vector{String})
 
-    comm, settings, mpi_cart_domain, fields = Simulation.Initialization(args)
+    comm, settings, mpi_cart_domain, fields = Simulation.initialization(args)
     rank = MPI.Comm_rank(comm)
     
     # initialize IOStream struct holding ADIOS-2 components for parallel I/O
@@ -44,7 +44,7 @@ function main(args::Vector{String})
     step::Int32 = restart_step
 
     while step < settings.steps
-        Simulation.Iterate!(fields, settings, mpi_cart_domain)
+        Simulation.iterate!(fields, settings, mpi_cart_domain)
         step += 1
 
         if step % settings.plotgap == 0
@@ -59,7 +59,7 @@ function main(args::Vector{String})
 
    #IO.close!(stream)
 
-   Simulation.Finalize()
+   Simulation.finalize()
 
 
 end

--- a/src/simulation/Common.jl
+++ b/src/simulation/Common.jl
@@ -2,7 +2,7 @@
    7-point stencil around the cell, 
    this is equally a host and a device function!
 """
-function Laplacian(i, j, k, var)
+function laplacian(i, j, k, var)
     @inbounds l = var[i - 1, j, k] + var[i + 1, j, k] + var[i, j - 1, k] +
                   var[i, j + 1, k] + var[i, j, k - 1] + var[i, j, k + 1] -
                   6.0 * var[i, j, k]
@@ -10,7 +10,7 @@ function Laplacian(i, j, k, var)
 end
 
 
-function Is_Inside(x, y, z, offsets, sizes)::Bool
+function is_inside(x, y, z, offsets, sizes)::Bool
     if x < offsets[1] || x >= offsets[1] + sizes[1]
         return false
     end

--- a/src/simulation/IO.jl
+++ b/src/simulation/IO.jl
@@ -45,7 +45,7 @@ end
 function write_step!(stream::IOStream, step::Int32, fields::Fields{T}) where {T}
 
     # this creates temporaries similar to Fortran
-    u_no_ghost, v_no_ghost = Simulation.Get_Fields(fields)
+    u_no_ghost, v_no_ghost = Simulation.get_fields(fields)
 
     # writer engine
     w = stream.engine
@@ -59,7 +59,7 @@ end
 
 function close!(stream::IOStream)
     ADIOS2.close(stream.engine)
-    ADIOS2.adios_Finalize(stream.adios)
+    ADIOS2.adios_finalize(stream.adios)
 end
 
 function _add_visualization_schemas(io, length)

--- a/src/simulation/Simulation.jl
+++ b/src/simulation/Simulation.jl
@@ -4,7 +4,7 @@ CUDA.jl, AMDGPU.jl, and KernelAbstractions.jl
 """
 module Simulation
 
-export Init_Domain, Init_Fields
+export init_domain, init_fields
 
 import MPI
 import Distributions
@@ -28,6 +28,7 @@ include("Simulation_CPU.jl")
 # include functions for all GPUs using KernelAbstractions.jl
 include("Simulation_KA.jl")
 
+# include functions for MPI communication
 include("communication.jl")
 
 end # module

--- a/src/simulation/Simulation_CPU.jl
+++ b/src/simulation/Simulation_CPU.jl
@@ -1,5 +1,5 @@
-function Init_Fields_CPU(settings::Settings,
-                          mcd::MPICartDomain, T)::Fields{T}
+function init_fields_CPU(settings::Settings,
+                         mcd::MPICartDomain, T)::Fields{T}
     size_x = mcd.proc_sizes[1]
     size_y = mcd.proc_sizes[2]
     size_z = mcd.proc_sizes[3]
@@ -24,7 +24,7 @@ function Init_Fields_CPU(settings::Settings,
     Threads.@threads for z in minL:maxL
         for y in minL:maxL
             for x in minL:maxL
-                if !Is_Inside(x, y, z, mcd.proc_offsets, mcd.proc_sizes)
+                if !is_inside(x, y, z, mcd.proc_offsets, mcd.proc_sizes)
                     continue
                 end
 
@@ -35,24 +35,24 @@ function Init_Fields_CPU(settings::Settings,
         end
     end
 
-    xy_face_t, xz_face_t, yz_face_t = Get_MPI_Faces(size_x, size_y, size_z, T)
+    xy_face_t, xz_face_t, yz_face_t = get_MPI_faces(size_x, size_y, size_z, T)
 
     fields = Fields(u, v, u_temp, v_temp, xy_face_t, xz_face_t, yz_face_t)
     return fields
 end
 
-function Iterate!(fields::Fields{T, N, Array{T, N}}, settings::Settings,
+function iterate!(fields::Fields{T, N, Array{T, N}}, settings::Settings,
                   mcd::MPICartDomain) where {T, N}
-    Exchange!(fields, mcd)
+    exchange!(fields, mcd)
     # this function is the bottleneck
-    Calculate!(fields, settings, mcd)
+    calculate!(fields, settings, mcd)
 
     # swap the names
     fields.u, fields.u_temp = fields.u_temp, fields.u
     fields.v, fields.v_temp = fields.v_temp, fields.v
 end
 
-function Calculate!(fields::Fields{T, N, Array{T, N}}, settings::Settings,
+function calculate!(fields::Fields{T, N, Array{T, N}}, settings::Settings,
                      mcd::MPICartDomain) where {T, N}
     Du = convert(T, settings.Du)
     Dv = convert(T, settings.Dv)
@@ -71,11 +71,11 @@ function Calculate!(fields::Fields{T, N, Array{T, N}}, settings::Settings,
                 v = fields.v[i, j, k]
 
                 # introduce a random disturbance on du
-                du = Du * Laplacian(i, j, k, fields.u) - u * v^2 +
+                du = Du * laplacian(i, j, k, fields.u) - u * v^2 +
                      F * (1.0 - u) +
                      noise * rand(Distributions.Uniform(-1, 1))
 
-                dv = Dv * Laplacian(i, j, k, fields.v) + u * v^2 -
+                dv = Dv * laplacian(i, j, k, fields.v) + u * v^2 -
                      (F + K) * v
 
                 # advance the next step
@@ -86,7 +86,7 @@ function Calculate!(fields::Fields{T, N, Array{T, N}}, settings::Settings,
     end
 end
 
-function Get_Fields(fields::Fields{T, N, Array{T, N}}) where {T, N}
+function get_fields(fields::Fields{T, N, Array{T, N}}) where {T, N}
     @inbounds begin
         u_no_ghost = fields.u[(begin + 1):(end - 1), (begin + 1):(end - 1),
                               (begin + 1):(end - 1)]

--- a/src/simulation/Simulation_CUDA.jl
+++ b/src/simulation/Simulation_CUDA.jl
@@ -1,7 +1,7 @@
 import CUDA
 
-function Init_Fields_CUDA(settings::Settings, mcd::MPICartDomain,
-                           T)::Fields{T, 3, <:CUDA.CuArray{T, 3}}
+function init_fields_CUDA(settings::Settings, mcd::MPICartDomain,
+                          T)::Fields{T, 3, <:CUDA.CuArray{T, 3}}
     size_x = mcd.proc_sizes[1]
     size_y = mcd.proc_sizes[2]
     size_z = mcd.proc_sizes[3]
@@ -24,31 +24,31 @@ function Init_Fields_CUDA(settings::Settings, mcd::MPICartDomain,
     threads = (16, 16)
     blocks = (settings.L, settings.L)
 
-    CUDA.@cuda threads=threads blocks=blocks Populate_CUDA!(u, v,
-                                                             cu_offsets,
-                                                             cu_sizes,
-                                                             minL, maxL)
+    CUDA.@cuda threads=threads blocks=blocks populate_CUDA!(u, v,
+                                                            cu_offsets,
+                                                            cu_sizes,
+                                                            minL, maxL)
     CUDA.synchronize()
 
-    xy_face_t, xz_face_t, yz_face_t = Get_MPI_Faces(size_x, size_y, size_z, T)
+    xy_face_t, xz_face_t, yz_face_t = get_MPI_faces(size_x, size_y, size_z, T)
 
     fields = Fields(u, v, u_temp, v_temp, xy_face_t, xz_face_t, yz_face_t)
     return fields
 end
 
-function Iterate!(fields::Fields{T, N, <:CUDA.CuArray{T, N}},
+function iterate!(fields::Fields{T, N, <:CUDA.CuArray{T, N}},
                   settings::Settings,
                   mcd::MPICartDomain) where {T, N}
-    Exchange!(fields, mcd)
+    exchange!(fields, mcd)
     # this function is the bottleneck
-    Calculate!(fields, settings, mcd)
+    calculate!(fields, settings, mcd)
 
     # swap the names
     fields.u, fields.u_temp = fields.u_temp, fields.u
     fields.v, fields.v_temp = fields.v_temp, fields.v
 end
 
-function Populate_CUDA!(u, v, offsets, sizes, minL, maxL)
+function populate_CUDA!(u, v, offsets, sizes, minL, maxL)
 
     # local coordinates (this are 1-index already)
     lz = (CUDA.blockIdx().x - Int32(1)) * CUDA.blockDim().x +
@@ -66,8 +66,8 @@ function Populate_CUDA!(u, v, offsets, sizes, minL, maxL)
             xoff = offsets[1]
 
             for x in minL:maxL
-                # check if global coordinates for Initialization are inside the region
-                if !Is_Inside(x, y, z, offsets, sizes)
+                # check if global coordinates for initialization are inside the region
+                if !is_inside(x, y, z, offsets, sizes)
                     continue
                 end
 
@@ -79,10 +79,10 @@ function Populate_CUDA!(u, v, offsets, sizes, minL, maxL)
     end
 end
 
-function Calculate!(fields::Fields{T, N, <:CUDA.CuArray{T, N}},
+function calculate!(fields::Fields{T, N, <:CUDA.CuArray{T, N}},
                      settings::Settings,
                      mcd::MPICartDomain) where {T, N}
-    function Calculte_Kernel!(u, v, u_temp, v_temp, sizes, Du, Dv, F, K,
+    function calculate_kernel!(u, v, u_temp, v_temp, sizes, Du, Dv, F, K,
                                noise, dt)
 
         # local coordinates (this are 1-index already)
@@ -98,11 +98,11 @@ function Calculate!(fields::Fields{T, N, <:CUDA.CuArray{T, N}},
                 u_ijk = u[i, j, k]
                 v_ijk = v[i, j, k]
 
-                du = Du * Laplacian(i, j, k, u) - u_ijk * v_ijk^2 +
+                du = Du * laplacian(i, j, k, u) - u_ijk * v_ijk^2 +
                      F * (1.0 - u_ijk) +
                      noise * rand(Distributions.Uniform(-1, 1))
 
-                dv = Dv * Laplacian(i, j, k, v) + u_ijk * v_ijk^2 -
+                dv = Dv * laplacian(i, j, k, v) + u_ijk * v_ijk^2 -
                      (F + K) * v_ijk
 
                 # advance the next step
@@ -124,7 +124,7 @@ function Calculate!(fields::Fields{T, N, <:CUDA.CuArray{T, N}},
     threads = (16, 16)
     blocks = (settings.L, settings.L)
 
-    CUDA.@cuda threads=threads blocks=blocks Calculte_Kernel!(fields.u,
+    CUDA.@cuda threads=threads blocks=blocks calculate_kernel!(fields.u,
                                                                fields.v,
                                                                fields.u_temp,
                                                                fields.v_temp,
@@ -134,7 +134,7 @@ function Calculate!(fields::Fields{T, N, <:CUDA.CuArray{T, N}},
     CUDA.synchronize()
 end
 
-function Get_Fields(fields::Fields{T, N, <:CUDA.CuArray{T, N}}) where {T, N}
+function get_fields(fields::Fields{T, N, <:CUDA.CuArray{T, N}}) where {T, N}
     u = Array(fields.u)
     u_no_ghost = u[(begin + 1):(end - 1), (begin + 1):(end - 1),
                    (begin + 1):(end - 1)]

--- a/src/simulation/Simulation_KA.jl
+++ b/src/simulation/Simulation_KA.jl
@@ -23,7 +23,7 @@ else DEV == :CPU
     const Backend = CPU()
 end
 
-function Init_Fields_CUDA(settings::Settings, mcd::MPICartDomain,
+function init_fields_CUDA(settings::Settings, mcd::MPICartDomain,
                            T)::Fields{T, 3, <:ArrayKA{T, 3}}
     size_x = mcd.proc_sizes[1]
     size_y = mcd.proc_sizes[2]
@@ -49,7 +49,7 @@ function Init_Fields_CUDA(settings::Settings, mcd::MPICartDomain,
     threads = (16, 16)
     nrange = (settings.L * threads[1], settings.L * threads[2])
 
-    kernel! = Populate_CUDA_Kernel!(Backend, threads)
+    kernel! = populate_CUDA_kernel!(Backend, threads)
     kernel!(u, v, 
             cu_offsets, 
             cu_sizes, 
@@ -57,18 +57,18 @@ function Init_Fields_CUDA(settings::Settings, mcd::MPICartDomain,
             ndrange=nrange)
 
     KernelAbstractions.synchronize(Backend)
-    xy_face_t, xz_face_t, yz_face_t = Get_MPI_Faces(size_x, size_y, size_z, T)
+    xy_face_t, xz_face_t, yz_face_t = get_MPI_faces(size_x, size_y, size_z, T)
 
     fields = Fields(u, v, u_temp, v_temp, xy_face_t, xz_face_t, yz_face_t)
     return fields
 end
 
-function Iterate!(fields::Fields{T, N, <:ArrayKA{T, N}},
+function iterate!(fields::Fields{T, N, <:ArrayKA{T, N}},
                   settings::Settings,
                   mcd::MPICartDomain) where {T, N}
-    Exchange!(fields, mcd)
+    exchange!(fields, mcd)
     # this function is the bottleneck
-    Calculate!(fields, settings, mcd)
+    calculate!(fields, settings, mcd)
 
     # swap the names
     fields.u, fields.u_temp = fields.u_temp, fields.u
@@ -77,7 +77,7 @@ end
 
 
 
-@kernel function Populate_CUDA_Kernel!(u, v, offsets, sizes, minL, maxL)
+@kernel function populate_CUDA_kernel!(u, v, offsets, sizes, minL, maxL)
 
 
     # local coordinates (this are 1-index already)
@@ -98,8 +98,8 @@ end
             xoff = offsets[1]
 
             for x in minL:maxL
-                # check if global coordinates for Initialization are inside the region
-                if !Is_Inside(x, y, z, offsets, sizes)
+                # check if global coordinates for initialization are inside the region
+                if !is_inside(x, y, z, offsets, sizes)
                     continue
                 end
 
@@ -111,10 +111,10 @@ end
     end
 end
 
-function Calculate!(fields::Fields{T, N, <:ArrayKA{T, N}},
+function calculate!(fields::Fields{T, N, <:ArrayKA{T, N}},
                      settings::Settings,
                      mcd::MPICartDomain) where {T, N}
-    @kernel function Calculte_Kernel!(u, v, u_temp, v_temp, sizes, Du, Dv, F, K,
+    @kernel function calculate_kernel!(u, v, u_temp, v_temp, sizes, Du, Dv, F, K,
                                noise, dt)
 
         # local coordinates (this are 1-index already)
@@ -132,11 +132,11 @@ function Calculate!(fields::Fields{T, N, <:ArrayKA{T, N}},
                 u_ijk = u[i, j, k]
                 v_ijk = v[i, j, k]
 
-                du = Du * Laplacian(i, j, k, u) - u_ijk * v_ijk^2 +
+                du = Du * laplacian(i, j, k, u) - u_ijk * v_ijk^2 +
                      F * (1.0 - u_ijk) +
                      noise * rand(Distributions.Uniform(-1, 1))
 
-                dv = Dv * Laplacian(i, j, k, v) + u_ijk * v_ijk^2 -
+                dv = Dv * laplacian(i, j, k, v) + u_ijk * v_ijk^2 -
                      (F + K) * v_ijk
 
                 # advance the next step
@@ -159,7 +159,7 @@ function Calculate!(fields::Fields{T, N, <:ArrayKA{T, N}},
     nrange = (settings.L * threads[1], settings.L * threads[2])
 
 
-    kernel! = Calculte_Kernel!(Backend, threads)
+    kernel! = calculate_kernel!(Backend, threads)
     kernel!(fields.u,
             fields.v,
             fields.u_temp,
@@ -173,7 +173,7 @@ function Calculate!(fields::Fields{T, N, <:ArrayKA{T, N}},
 
 end
 
-function Get_Fields(fields::Fields{T, N, <:ArrayKA{T, N}}) where {T, N}
+function get_fields(fields::Fields{T, N, <:ArrayKA{T, N}}) where {T, N}
     u = Array(fields.u)
     u_no_ghost = u[(begin + 1):(end - 1), (begin + 1):(end - 1),
                    (begin + 1):(end - 1)]

--- a/test/unit/simulation/unit-IO.jl
+++ b/test/unit/simulation/unit-IO.jl
@@ -11,7 +11,7 @@ import GrayScott: Settings, MPICartDomain, Fields
 @testset "unit-IO.init" begin
     settings = Settings()
     mpi_cart_domain = MPICartDomain()
-    fields = Simulation.Init_Fields(settings, mpi_cart_domain, Float32)
+    fields = Simulation.init_fields(settings, mpi_cart_domain, Float32)
 
     @test eltype(fields.u) == Float32
     @test eltype(fields.v) == Float32
@@ -28,8 +28,8 @@ end
 @testset "unit-IO.write" begin
     settings = Settings()
     settings.L = 6
-    mpi_cart_domain = Simulation.Init_Domain(settings, MPI.COMM_WORLD)
-    fields = Simulation.Init_Fields(settings, mpi_cart_domain, Float32)
+    mpi_cart_domain = Simulation.init_domain(settings, MPI.COMM_WORLD)
+    fields = Simulation.init_fields(settings, mpi_cart_domain, Float32)
     stream = IO.init(settings, mpi_cart_domain, fields)
     IO.write_step!(stream, Int32(0), fields)
     IO.close!(stream)

--- a/test/unit/simulation/unit-Simulation.jl
+++ b/test/unit/simulation/unit-Simulation.jl
@@ -10,8 +10,8 @@ import .Simulation: Settings, MPICartDomain, Fields
 
 @testset "unit-Simulation.init" begin
     settings = Settings()
-    mpi_cart_domain = Simulation.Init_Domain(settings, MPI.COMM_WORLD)
-    fields = Simulation.Init_Fields(settings, mpi_cart_domain, Float32)
+    mpi_cart_domain = Simulation.init_domain(settings, MPI.COMM_WORLD)
+    fields = Simulation.init_fields(settings, mpi_cart_domain, Float32)
 
     @test typeof(fields) == Fields{Float32, 3, Array{Float32, 3}}
 end
@@ -19,10 +19,10 @@ end
 @testset "unit-Simulation.iterate" begin
     settings = Settings()
     settings.L = 2
-    mpi_cart_domain = Simulation.Init_Domain(settings, MPI.COMM_WORLD)
-    fields = Simulation.Init_Fields(settings, mpi_cart_domain, Float32)
+    mpi_cart_domain = Simulation.init_domain(settings, MPI.COMM_WORLD)
+    fields = Simulation.init_fields(settings, mpi_cart_domain, Float32)
 
-    Simulation.Iterate!(fields, settings, mpi_cart_domain)
+    Simulation.iterate!(fields, settings, mpi_cart_domain)
 
     if verbose
         sleep(0.01)

--- a/test/unit/simulation/unit-Simulation_CUDA.jl
+++ b/test/unit/simulation/unit-Simulation_CUDA.jl
@@ -7,16 +7,16 @@ import .Simulation: Settings, MPICartDomain, Fields
 
 using CUDA
 
-@testset "unit-Simulation.Init_Fields-cuda" begin
+@testset "unit-Simulation.init_fields-cuda" begin
     function test_init_cuda(L)
         settings = Settings()
         settings.L = L
-        mpi_cart_domain = Simulation.Init_Domain(settings, MPI.COMM_WORLD)
+        mpi_cart_domain = Simulation.init_domain(settings, MPI.COMM_WORLD)
 
-        fields = Simulation.Init_Fields(settings, mpi_cart_domain, Float32)
+        fields = Simulation.init_fields(settings, mpi_cart_domain, Float32)
 
         settings.backend = "CUDA"
-        fields_cuda = Simulation.Init_Fields(settings, mpi_cart_domain, Float32)
+        fields_cuda = Simulation.init_fields(settings, mpi_cart_domain, Float32)
 
         @test fields.u ≈ Array(fields_cuda.u)
         @test fields.v ≈ Array(fields_cuda.v)


### PR DESCRIPTION
Removes changes that applied title-casing to function names, but generally keeps the rest of the changes.